### PR TITLE
Fix txn-time order check on objects w/Date index

### DIFF
--- a/R/addTxn.R
+++ b/R/addTxn.R
@@ -78,8 +78,11 @@ addTxn <- function(Portfolio, Symbol, TxnDate, TxnQty, TxnPrice, ..., TxnFees=0,
 
     PrevPosQty = getPosQty(pname, Symbol, TxnDate)
     
-    if(!is.timeBased(TxnDate) ){
-        TxnDate<-as.POSIXct(TxnDate)
+    if(!inherits(TxnDate, "POSIXct")) {
+      if(inherits(TxnDate, "Date"))
+        TxnDate <- as.POSIXct(TxnDate, tz="UTC")
+      else
+        TxnDate <- as.POSIXct(TxnDate)
     }
 
     lastTxnDate <- end(Portfolio$symbols[[Symbol]]$txn)

--- a/tests/unitTests/runitAddTxn.R
+++ b/tests/unitTests/runitAddTxn.R
@@ -3,9 +3,11 @@
 test.addTxn <- function() {
   on.exit({
     # remove objects created by unit tests
-    try(rm_currencies("USD"))
-    try(rm_stocks(symbols))
-    try(rm(list=paste0("portfolio.",p), pos=.blotter))
+    try({
+      rm_currencies("USD")
+      rm_stocks(symbols)
+      rm(list=paste0("portfolio.",p), pos=.blotter)
+    }, silent=FALSE)
   })
 
   currency("USD")
@@ -41,33 +43,135 @@ test.addTxn <- function() {
   # summary <- calcPortfSummary(portfolio)
 }
 
-test.addTxn_TxnDate_out_of_order_errors <- function() {
+test.addTxn_POSIXct_TxnDate_in_order_works <- function() {
   on.exit({
     # remove objects created by unit tests
-    try(rm_currencies("USD"))
-    try(rm_stocks("A"))
-    try(rm(list=paste0("portfolio.",p), pos=.blotter))
+    try({
+      rm_currencies("USD")
+      rm_stocks("A")
+      rm(list=paste0("portfolio.",p), pos=.blotter)
+    }, silent=FALSE)
   })
 
   currency("USD")
   stock("A", currency = "USD")
-  initPortf("TxnDateOrder", "A")
-
   # Initialize a portfolio object 'p'
-  # Creating portfolio:
-  p <- initPortf("runitAddTxn", symbols="A")
+  p <- initPortf("TxnDateOrder", symbols="A")
+
+  # Trades must be made in date order.
+  addTxn(p, "A", "2007-01-04", -50,  97.1)
+  checkException(addTxn(p, "A", "2007-01-05",  50,  96.5))
+}
+
+test.addTxn_Date_TxnDate_in_order_works <- function() {
+  on.exit({
+    # remove objects created by unit tests
+    try({
+      rm_currencies("USD")
+      rm_stocks("A")
+      rm(list=paste0("portfolio.",p), pos=.blotter)
+    })
+  })
+
+  currency("USD")
+  stock("A", currency = "USD")
+  # Initialize a portfolio object 'p'
+  p <- initPortf("TxnDateOrder", symbols="A")
+
+  # Trades must be made in date order.
+  addTxn(p, "A", as.Date("2007-01-04"), -50,  97.1)
+  checkException(addTxn(p, "A", as.Date("2007-01-05"),  50,  96.5))
+}
+
+test.addTxn_POSIXct_TxnDate_out_of_order_errors <- function() {
+  on.exit({
+    # remove objects created by unit tests
+    try({
+      rm_currencies("USD")
+      rm_stocks("A")
+      rm(list=paste0("portfolio.",p), pos=.blotter)
+    })
+  })
+
+  currency("USD")
+  stock("A", currency = "USD")
+  # Initialize a portfolio object 'p'
+  p <- initPortf("TxnDateOrder", symbols="A")
 
   # Trades must be made in date order.
   addTxn(p, "A", "2007-01-04", -50,  97.1)
   checkException(addTxn(p, "A", "2007-01-03",  50,  96.5))
 }
 
+test.addTxn_Date_TxnDate_out_of_order_errors <- function() {
+  on.exit({
+    # remove objects created by unit tests
+    try({
+        rm_currencies("USD")
+        rm_stocks("A")
+        rm(list=paste0("portfolio.",p), pos=.blotter)
+    }, silent = FALSE)
+  })
+
+  currency("USD")
+  stock("A", currency = "USD")
+  # Initialize a portfolio object 'p'
+  p <- initPortf("TxnDateOrder", symbols="A")
+
+  # Trades must be made in date order.
+  addTxn(p, "A", as.Date("2007-01-04"), -50,  97.1)
+  checkException(addTxn(p, "A", as.Date("2007-01-03"),  50,  96.5))
+}
+
+test.addTxn_POSIXct_TxnDate_in_order_works <- function() {
+  on.exit({
+    # remove objects created by unit tests
+    try({
+        rm_currencies("USD")
+        rm_stocks("A")
+        rm(list=paste0("portfolio.",p), pos=.blotter)
+    }, silent = TRUE)
+  })
+
+  currency("USD")
+  stock("A", currency = "USD")
+  # Initialize a portfolio object 'p'
+  p <- initPortf("TxnDateOrder", symbols="A")
+
+  # Trades must be made in date order.
+  addTxn(p, "A", "2007-01-04", -50,  97.1)
+  addTxn(p, "A", "2007-01-05",  50,  96.5)
+}
+
+test.addTxn_Date_TxnDate_in_order_works <- function() {
+  on.exit({
+    # remove objects created by unit tests
+    try({
+        rm_currencies("USD")
+        rm_stocks("A")
+        rm(list=paste0("portfolio.",p), pos=.blotter)
+    }, silent = FALSE)
+  })
+
+  currency("USD")
+  stock("A", currency = "USD")
+  # Initialize a portfolio object 'p'
+  p <- initPortf("TxnDateOrder", symbols="A")
+
+  # Trades must be made in date order.
+  addTxn(p, "A", as.Date("2007-01-04"), -50,  97.1)
+  addTxn(p, "A", as.Date("2007-01-05"),  50,  96.5)
+}
+
 test.addTxns <- function() {
   on.exit({
     # remove objects created by unit tests
-    try(rm_currencies("USD"), silent=TRUE)
-    try(rm_stocks("AMZN"), silent=TRUE)
-    try(rm(list=c("account.amzn_acct","portfolio.amzn_txn","portfolio.amzn_txns"), pos=.blotter), silent=TRUE)
+    try({
+        rm_currencies("USD")
+        rm_stocks("A")
+        rm(list=c("account.amzn_acct","portfolio.amzn_txn",
+                  "portfolio.amzn_txns"), pos=.blotter)
+    }, silent = FALSE)
   })
 
   # load the example data
@@ -97,12 +201,15 @@ test.addTxns <- function() {
   checkIdentical(t1, t2)
 }
 
-test.addTxns_TxnDate_out_of_order_errors <- function() {
+test.addTxns_POSIXct_TxnDate_out_of_order_errors <- function() {
   on.exit({
     # remove objects created by unit tests
-    try(rm_currencies("USD"), silent=TRUE)
-    try(rm_stocks("A"), silent=TRUE)
-    try(rm(list=c("account.amzn_acct","portfolio.amzn_txn","portfolio.amzn_txns"), pos=.blotter), silent=TRUE)
+    try({
+        rm_currencies("USD")
+        rm_stocks("A")
+        rm(list=c("account.amzn_acct","portfolio.amzn_txn",
+                  "portfolio.amzn_txns"), pos=.blotter)
+    }, silent = FALSE)
   })
 
   currency("USD")
@@ -110,6 +217,28 @@ test.addTxns_TxnDate_out_of_order_errors <- function() {
 
   # Initialize the account/portfolios
   initAcct("amzn_acct", portfolios="amzn_txns", initEq=10000)
+  initPortf("amzn_txns", symbols="AMZN")
+
+  # Add the transactions to the portfolios
+  addTxns("amzn_txns", "AMZN", TxnData=amzn.trades)
+  # Trades must be made in date order.
+  checkException(addTxns("amzn_txns", "AMZN", TxnData=amzn.trades[1:2,]))
+}
+
+test.addTxns_Date_TxnDate_out_of_order_errors <- function() {
+  on.exit({
+    # remove objects created by unit tests
+    try({
+        rm_currencies("USD")
+        rm_stocks("A")
+        rm(list=c("account.amzn_acct","portfolio.amzn_txns"), pos=.blotter)
+    }, silent = FALSE)
+  })
+
+  currency("USD")
+  stock("AMZN", currency="USD", multiplier=1)
+
+  # Initialize the account/portfolios
   initPortf("amzn_txns", symbols="AMZN")
 
   # Add the transactions to the portfolios


### PR DESCRIPTION
Transactions should always be added to the portfolio in time-order.
Strange behavior can occur if they're added out of order. But the
blotter 'txn' table is always a POSIXct index, so the comparison
fails if the user supplies data with a Date index.

Check if 'TxnDate' does not inherit from POSIXct (rather than checking
if it's time-based). If it's not POSIXct, check if it's Date and then
convert it to POSIXct with a UTC timezone. Otherwise just call
as.POSIXct() as before.

Fixes #51.